### PR TITLE
Fix incorrect language standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
-CFLAGS+=" -std=c11"
+CFLAGS+=" -std=gnu11"
 
 # Checks for libraries.
 PKG_CHECK_MODULES(libimobiledevice, libimobiledevice-1.0 >= 1.2.1)


### PR DESCRIPTION
This project uses `fseeko`, `ftello` and `strdup`, which are POSIX extensions. Compiling with `-std=c11`, which doesn't support these functions, causes the following warnings:
```
common.c: In function 'read_file':
common.c:172:2: warning: implicit declaration of function 'fseeko'; did you mean 'fseek'? [-Wimplicit-function-declaration]
  172 |  fseeko(file, 0, SEEK_END);
      |  ^~~~~~
      |  fseek
common.c:173:11: warning: implicit declaration of function 'ftello'; did you mean 'ftell'? [-Wimplicit-function-declaration]
  173 |  length = ftello(file);
      |           ^~~~~~
      |           ftell
normal.c: In function 'normal_idevice_new':
normal.c:160:18: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
  160 |   client->udid = strdup(devices[j]);
      |                  ^~~~~~
      |                  strcmp
normal.c:160:16: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  160 |   client->udid = strdup(devices[j]);
      |                ^
recovery.c: In function 'recovery_client_new':
recovery.c:88:19: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
   88 |    client->srnm = strdup(device_info->srnm);
      |                   ^~~~~~
      |                   strcmp
recovery.c:88:17: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
   88 |    client->srnm = strdup(device_info->srnm);
      |                 ^
```
It also causes a segmentation fault when running `igetnonce` while a device is connected. To fix this, change `-std=c11` to `-std=gnu11`.